### PR TITLE
Make vue a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
       "require": "./dist/vue3-promise-dialog.umd.js"
     }
   },
-  "dependencies": {
-    "vue": "^3.2.26"
+  "peerDependencies": {
+    "vue": "^3.x"
   },
   "devDependencies": {
     "@types/node": "^17.0.12",


### PR DESCRIPTION
This is better because specifying vue as a dependency, with a specific version, is not necessary and can be buggy.
There is no need for the vue package in node_modules, it could even be used per cdn.