### PR TITLE
Export `closeDialog`

### DIFF
--- a/lib/components/DialogWrapper.vue
+++ b/lib/components/DialogWrapper.vue
@@ -1,14 +1,15 @@
 <template>
   <transition v-bind="transitionAttrs">
     <component :is="dialogRef.dialog" v-if="dialogRef && dialogRef.wrapper === name"
-               v-bind="dialogRef.props"></component>
+               v-bind="dialogRef.props"
+               ref="dialogInstance"></component>
   </transition>
 </template>
 
 <script lang="ts">
 
-import {defineComponent} from "vue";
-import {dialogRef} from "../ts/lib";
+import { ComponentPublicInstance, defineComponent, ref, watch } from "vue";
+import { dialogRef } from "../ts/lib";
 
 export default defineComponent({
   name: 'DialogWrapper',
@@ -20,9 +21,18 @@ export default defineComponent({
     },
     transitionAttrs: Object
   },
-  setup(props, context) {
+  setup() {
+    const dialogInstance = ref<ComponentPublicInstance<typeof dialogRef.value.dialog>>();
+
+    watch(dialogInstance, () => {
+      if (dialogRef.value) {
+        dialogRef.value.comp = dialogInstance.value
+      }
+    })
+
     return {
-      dialogRef
+      dialogRef,
+      dialogInstance
     }
   }
 })

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,8 +1,9 @@
 import DialogWrapper from "./components/DialogWrapper.vue"
-import {openDialog, PromiseDialog} from "./ts/lib";
+import {openDialog, closeDialog, PromiseDialog} from "./ts/lib";
 
 export {
     DialogWrapper,
     PromiseDialog,
-    openDialog
+    openDialog,
+    closeDialog
 }

--- a/lib/ts/lib.ts
+++ b/lib/ts/lib.ts
@@ -1,7 +1,8 @@
-import {Component, shallowRef} from "vue";
+import { Component, shallowRef } from "vue";
 import {DefineComponent} from "@vue/runtime-core";
 
 export interface DialogInstance {
+    comp?: any; //TODO
     dialog: Component;
     wrapper: string;
     props: any;
@@ -14,6 +15,9 @@ export const dialogRef = shallowRef<DialogInstance>();
  * Closes the currently opened dialog, resolving the promise with the given data.
  */
 export function closeDialog(data: any) {
+    if (data === undefined) {
+        data = dialogRef.value.comp.returnValue();
+    }
     dialogRef.value.resolve(data);
     dialogRef.value = null;
 }
@@ -44,7 +48,7 @@ type ReturnType<C extends DefineComponent<any, any, any, any, any>> = BindingRet
 
 /**
  * Opens a dialog.
- * @param dialog The dialog yo want to open.
+ * @param dialog The dialog you want to open.
  * @param props The props to be passed to the dialog.
  * @param wrapper The dialog wrapper you want the dialog to open into.
  * @return A promise that resolves when the dialog is closed
@@ -62,11 +66,11 @@ export function openDialog<C extends DefineComponent<any, any, any, any, any>>(d
 
 export const PromiseDialog = {
     install: (app, options) => {
-        app.config.globalProperties.$close = (comp, alternateValue) => {
+        app.config.globalProperties.$close = (alternateValue) => {
             if (alternateValue !== undefined) {
                 closeDialog(alternateValue);
             } else {
-                closeDialog(comp.returnValue());
+                closeDialog(dialogRef.value.comp.returnValue());
             }
         }
     }

--- a/src/dialogs/components/OkCancelBox.vue
+++ b/src/dialogs/components/OkCancelBox.vue
@@ -9,8 +9,8 @@
       </div>
       <div class="footer">
         <Button :label="cancelLabel" type="button" class="p-button-raised" style="margin-right: 10px"
-                @click="$close(this.$parent, null)"/>
-        <Button :label="okLabel" type="submit" class="p-button-raised" @click="$close(this.$parent)"
+                @click="$close(null)"/>
+        <Button :label="okLabel" type="submit" class="p-button-raised" @click="$close()"
                 :disabled="!valid"/>
       </div>
     </form>


### PR DESCRIPTION
Allows to close a dialog from within the setup function of the dialog component

Closes #4 

TODO: Fix typing of `comp` and update docs (we no longer should pass `this` when calling `$close`)