### PR TITLE
Feat: fallback to undefined

### DIFF
--- a/lib/ts/lib.ts
+++ b/lib/ts/lib.ts
@@ -15,9 +15,9 @@ export const dialogRef = shallowRef<DialogInstance>();
  * Closes the currently opened dialog, resolving the promise with the return value of the dialog, or with the given
  * data if any.
  */
-export function closeDialog(data?: any) {
+export function closeDialog(data?: any): void {
     if (data === undefined) {
-        data = dialogRef.value.comp.returnValue();
+        data = 'function' === typeof dialogRef.value.comp.returnValue ? dialogRef.value.comp.returnValue() : undefined;
     }
     dialogRef.value.resolve(data);
     dialogRef.value = null;


### PR DESCRIPTION
Allows resolving modals with `closeDialog()` even if no `returnValue` is exposed from the dialog component.
This means the underlying promise will legitimately be resolved to `undefined` without raising an error.

Addresses #8 