### PR TITLE
Feat: resolve / reject dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,12 @@ let ok = await confirm("Are you sure ?");
 ### Closing dialogs
 
 Your dialog must define a `returnValue` function. You may do so either in the setup function using Composition API or as
-a method using Options API. To close the dialog, call `closeDialog()`. When you do so, the promise will resolve to the
+a method using Options API. To close the dialog, call `resolveDialog()`. When you do so, the promise will resolve to the
 result of the `returnValue` function. You may also resolve the promise to something else (for example null) by passing a
-value to `closeDialog()`.
+value to `resolveDialog()`. 
+
+Alertnatively, you can call `rejectDialog()`. This will throw a `DismissedDialog` error (you can also pass your own error as an argument),
+meaning your promise won't be resolved, but rejected. As a result, the dialog will be closed as well.
 
 ### Typescript
 
@@ -178,8 +181,8 @@ for the centered div. It has one slot which is the content of the centered div.
 The OkCancelBox.vue component is a Box that serves as base for all dialogs that include OK and CANCEL buttons. It has
 two slots : `header` and `body`. Body is where the controls of the dialog reside. It has a `valid` prop. If `valid` is
 false, the OK button is disabled. The whole thing is included into a `form` tag so that hitting enter when a control has
-focus triggers a click on the OK button. When OK is clicked, `closeDialog` is called.
-When CANCEL is clicked, `closeDialog` is called with a null return value.
+focus triggers a click on the OK button. When OK is clicked, `resolveDialog` is called.
+When CANCEL is clicked, `resolveDialog` is called with a null return value.
 
 ### ConfirmDialog.vue
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,11 @@
 import DialogWrapper from "./components/DialogWrapper.vue"
-import {openDialog, closeDialog, PromiseDialog} from "./ts/lib";
+import {openDialog, closeDialog, resolveDialog, rejectDialog, PromiseDialog} from "./ts/lib";
 
 export {
     DialogWrapper,
     PromiseDialog,
     openDialog,
-    closeDialog
+    closeDialog,
+    resolveDialog,
+    rejectDialog
 }


### PR DESCRIPTION
I suggest an API change to be able to reject the underlying promise of a dialog, by calling either `resolveDialog()` or `rejectDialog()` instead of `closeDialog()`.

When `rejectDialog()` is invoked (when clicking on a cancel button, for instance), it rejects the underlying promise with a `DismissedDialog` error.

Useful when chaining dialogs, this allows turning this:

```js
async function addBook() {
  let book = await openBookNameDialog(BookNameDialog, {});
  if (null === book) {
    return;
  }

  book = await openBookISBNDialog(BookISBNDialog, {book});

  if (null === book) {
    return;
  }

  book = await openBookAuthorDialog(BookAuthorDialog, {book});

  if (null === book) {
    return;
  }

  books.add(book)
}
```

into this:
```js
async function addBook() {
  try {
    let book = await openBookNameDialog(BookNameDialog, {});
    book = await openBookISBNDialog(BookISBNDialog, {book});
    book = await openBookAuthorDialog(BookAuthorDialog, {book});
    books.add(book);
  } catch (e) {
    if (!(e instanceof DismissedDialog)) {
      throw e;
    }
  }
}
```

I kept `closeDialog()` for BC - when you pass an `Error` into `closeDialog()`, it will internally call `rejectDialog()`.